### PR TITLE
fix: run_host.sh CRLF line endings break native host on Linux/macOS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,7 @@
+# Unix shell scripts must stay LF even on Windows checkouts (core.autocrlf),
+# otherwise run_host.sh ships with CRLF and the native messaging host fails to
+# start on macOS/Linux: run_host.sh: line N: $'\r': command not found
+*.sh text eol=lf
+*.bat text eol=crlf
+
 *.onnx filter=lfs diff=lfs merge=lfs -text

--- a/app/native-server/src/scripts/build.ts
+++ b/app/native-server/src/scripts/build.ts
@@ -84,7 +84,11 @@ const windowsWrapperDestPath = path.join(distDir, 'run_host.bat');
 
 try {
   if (fs.existsSync(macOsWrapperSourcePath)) {
-    fs.copyFileSync(macOsWrapperSourcePath, macOsWrapperDestPath);
+    // run_host.sh runs under bash on macOS/Linux; force LF so a CRLF working
+    // copy (git core.autocrlf on Windows) can't ship a script that fails with
+    // `$'\r': command not found`.
+    const wrapperContent = fs.readFileSync(macOsWrapperSourcePath, 'utf8').replace(/\r\n/g, '\n');
+    fs.writeFileSync(macOsWrapperDestPath, wrapperContent, 'utf8');
     console.log(`已将 ${macOsWrapperSourcePath} 复制到 ${macOsWrapperDestPath}`);
   } else {
     console.error(`错误: macOS 包装脚本源文件未找到: ${macOsWrapperSourcePath}`);


### PR DESCRIPTION
## Problem

On Linux (and macOS), the extension stays at **"Service Not Connected"** and the MCP server on port 12306 never comes up. Running the native host wrapper manually reveals why:

```
run_host.sh: line 2: $'\r': command not found
run_host.sh: line 6: $'\r': command not found
run_host.sh: line 52: syntax error near unexpected token `}'
```

The published `dist/run_host.sh` has **CRLF** line terminators, so `bash` chokes on the `\r`, the native messaging host never starts, and `startServer(12306)` is never reached.

## Root cause

`app/native-server/src/scripts/run_host.sh` is stored as LF in git, but there is no `.gitattributes` rule for `*.sh`. On a Windows checkout with `core.autocrlf=true` the working copy becomes CRLF, and `build.ts` copies it **verbatim** (`fs.copyFileSync`) into `dist/run_host.sh`, which then gets published to npm with CRLF.

## Fix

1. **`.gitattributes`** — force `*.sh` to `eol=lf` (and `*.bat` to `eol=crlf`) so shell scripts stay LF on every platform, including Windows.
2. **`build.ts`** — normalize CRLF→LF when copying `run_host.sh` into `dist`, as a belt-and-suspenders guard so a stale CRLF working copy can never ship a broken wrapper again.

`.bat` files and the Windows path are untouched.

## Verified

After applying, the Chrome-spawned native host (`node dist/index.js`, parent = chrome) starts cleanly, binds `127.0.0.1:12306`, and `initialize` returns HTTP 200 on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)